### PR TITLE
Update tr Translation

### DIFF
--- a/resources/lang/tr/actions.php
+++ b/resources/lang/tr/actions.php
@@ -3,7 +3,7 @@
 return [
 
     'active_locale' => [
-        'label' => 'Yerel ayar',
+        'label' => 'Aktif Dil',
     ],
 
 ];


### PR DESCRIPTION
As a native Turkish speaker, "Aktif Dil" is more appropriate than "Yerel Ayar". "Ayar" word refers to "Setting" in English.