### PR TITLE
Fix language switch triggering validation exception

### DIFF
--- a/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -83,7 +83,7 @@ trait Translatable
 
         try {
             $this->otherLocaleData[$this->oldActiveLocale] = Arr::only(
-                $this->form->getState(),
+                $this->form->getRawState(),
                 $translatableAttributes
             );
 


### PR DESCRIPTION
When there is data in one language, then if we switch to another language if the data is empty, then we switch back the original language, this would trigger the validation exception as, we were using getState for the form method. This is fixed by using getRawState() method.