### PR TITLE
fix: replace resource_path to lang_path in lang publishing

### DIFF
--- a/src/SpatieLaravelTranslatablePluginServiceProvider.php
+++ b/src/SpatieLaravelTranslatablePluginServiceProvider.php
@@ -10,7 +10,7 @@ class SpatieLaravelTranslatablePluginServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../resources/lang' => resource_path('lang/vendor/filament-spatie-laravel-translatable-plugin-translations'),
+                __DIR__ . '/../resources/lang' => lang_path('vendor/filament-spatie-laravel-translatable-plugin-translations'),
             ], 'filament-spatie-laravel-translatable-plugin-translations');
         }
 


### PR DESCRIPTION
version 3.x require "spatie/laravel-translatable": "^6.0", wich require Laravel 9+.  In Laravel 9 was added method lang_path(), because default path is migrated from 'resources' to base folder.

When spatie-laravel-translatable-plugin create folder 'lang' in 'resources', Laravel don't get translation from base 'lang' folder anymore.

Test this, please. Thanks.