### PR TITLE
Add option to use fallback locale

### DIFF
--- a/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
+++ b/src/Resources/Pages/Concerns/HasTranslatableFormWithExistingRecordData.php
@@ -20,7 +20,11 @@ trait HasTranslatableFormWithExistingRecordData
             $translatedData = [];
 
             foreach ($translatableAttributes as $attribute) {
-                $translatedData[$attribute] = $record->getTranslation($attribute, $locale, useFallbackLocale: false);
+                $translatedData[$attribute] = $record->getTranslation(
+                    $attribute,
+                    $locale,
+                    useFallbackLocale: filament('spatie-laravel-translatable')->getUseFallbackLocale()
+                );
             }
 
             if ($locale !== $this->activeLocale) {

--- a/src/SpatieLaravelTranslatableContentDriver.php
+++ b/src/SpatieLaravelTranslatableContentDriver.php
@@ -108,7 +108,11 @@ class SpatieLaravelTranslatableContentDriver implements TranslatableContentDrive
         }
 
         foreach ($record->getTranslatableAttributes() as $attribute) {
-            $attributes[$attribute] = $record->getTranslation($attribute, $this->activeLocale, useFallbackLocale: false);
+            $attributes[$attribute] = $record->getTranslation(
+                $attribute,
+                $this->activeLocale,
+                useFallbackLocale: filament('spatie-laravel-translatable')->getUseFallbackLocale()
+            );
         }
 
         return $attributes;

--- a/src/SpatieLaravelTranslatablePlugin.php
+++ b/src/SpatieLaravelTranslatablePlugin.php
@@ -9,6 +9,8 @@ class SpatieLaravelTranslatablePlugin implements Plugin
 {
     protected ?array $defaultLocales = [];
 
+    protected bool $useFallbackLocale = false;
+
     protected ?Closure $getLocaleLabelUsing = null;
 
     final public function __construct()
@@ -44,6 +46,18 @@ class SpatieLaravelTranslatablePlugin implements Plugin
     public function defaultLocales(?array $defaultLocales = null): static
     {
         $this->defaultLocales = $defaultLocales;
+
+        return $this;
+    }
+
+    public function getUseFallbackLocale(): bool
+    {
+        return $this->useFallbackLocale;
+    }
+
+    public function useFallbackLocale(bool $useFallbackLocale = false): static
+    {
+        $this->useFallbackLocale = $useFallbackLocale;
 
         return $this;
     }

--- a/src/SpatieLaravelTranslatablePlugin.php
+++ b/src/SpatieLaravelTranslatablePlugin.php
@@ -55,7 +55,7 @@ class SpatieLaravelTranslatablePlugin implements Plugin
         return $this->useFallbackLocale;
     }
 
-    public function useFallbackLocale(bool $useFallbackLocale = false): static
+    public function useFallbackLocale(bool $useFallbackLocale = true): static
     {
         $this->useFallbackLocale = $useFallbackLocale;
 


### PR DESCRIPTION
Currently when you set a locale where not content is set, the form is empty. This PR adds an option to fill the form with the fallback locale.