### PR TITLE
fix switch locals with get state 

### DIFF
--- a/src/Resources/Pages/EditRecord/Concerns/Translatable.php
+++ b/src/Resources/Pages/EditRecord/Concerns/Translatable.php
@@ -82,13 +82,13 @@ trait Translatable
 
         try {
             $this->otherLocaleData[$this->oldActiveLocale] = Arr::only(
-                $this->form->getRawState(),
+                $this->form->getState(),
                 $translatableAttributes
             );
 
             $this->form->fill([
                 ...Arr::except(
-                    $this->form->getRawState(),
+                    $this->form->getState(),
                     $translatableAttributes
                 ),
                 ...$this->otherLocaleData[$this->activeLocale] ?? [],


### PR DESCRIPTION
… translatable concerns.

I have a bug. Uuid write in DB, when switch locales. 

{
"uk":{"f7647c90-1ec6-490d-b6787feda8472a81":"charity/images/01K6AFMSPP5Z1RWDD4C3R05Q6E.webp"},
"en":"charity/images/01K6AFNJYGZW1XV5DJGDN9Q3D0.webp"
}

Please check and merge this PR.