### PR TITLE
fix missing import for Arr in HasActiveLocaleSwitcher

### DIFF
--- a/src/Resources/Concerns/HasActiveLocaleSwitcher.php
+++ b/src/Resources/Concerns/HasActiveLocaleSwitcher.php
@@ -4,6 +4,7 @@ namespace Filament\Resources\Concerns;
 
 use Filament\SpatieLaravelTranslatableContentDriver;
 use Filament\Support\Contracts\TranslatableContentDriver;
+use Illuminate\Support\Arr;
 use Illuminate\Validation\ValidationException;
 
 trait HasActiveLocaleSwitcher


### PR DESCRIPTION
## 🐛 Fix missing import for `Arr` in `HasActiveLocaleSwitcher`

### Description
This pull request fixes an error that occurs when switching locales in a translatable Filament resource.

**Error message:**


### Related Issue
Fixes [lara-zeus/translatable#38](https://github.com/lara-zeus/translatable/issues/38)

### Cause
The `Arr` helper was referenced but not imported in `HasActiveLocaleSwitcher.php`.

### Fix
Added the missing import:
```php
use Illuminate\Support\Arr;
